### PR TITLE
Fixed files not running from examples directory

### DIFF
--- a/examples/basic_window.py
+++ b/examples/basic_window.py
@@ -1,3 +1,11 @@
+# Add this to each example, not sure how make this simpler
+import os
+import sys
+current_dir = os.path.dirname(os.path.abspath(__file__))
+parent_dir = os.path.dirname(current_dir)
+sys.path.append(parent_dir)
+######
+
 import jelly
 import sdl2
 import sdl2.ext
@@ -5,7 +13,6 @@ import sdl2.sdlgfx
 
 # creates a 500 x 500 window titled "Hello, World!"
 window = jelly.Window("Hello, World!", 500, 500)
-
 
 # basic game loop to refresh to window
 # eventually jelly may have its own game loop and event system

--- a/jelly/circle.py
+++ b/jelly/circle.py
@@ -9,7 +9,9 @@ class Circle:
         self.isFilled = isFilled
         self.color = color
 
+        # *parmas unpacks the tuple
+        params = (window.renderer.renderer, x, y, radius, self.color[0], self.color[1], self.color[2], 255) 
         if isFilled:
-            sdl2.sdlgfx.filledCircleRGBA(window.renderer.renderer, x, y, radius, self.color[0], self.color[1], self.color[2], 255)
+            sdl2.sdlgfx.filledCircleRGBA(*params)
         else:
-            sdl2.sdlgfx.circleRGBA(window.renderer.renderer, x, y, radius, self.color[0], self.color[1], self.color[2], 255)
+            sdl2.sdlgfx.circleRGBA(*params, 255)

--- a/jelly/rect.py
+++ b/jelly/rect.py
@@ -35,7 +35,8 @@ class Rect:
         self.window = window
         self.isFilled = isFilled
 
+        params = (window.renderer.renderer, self.x1, self.y1, self.x2, self.y2, sdl2.ext.Color(self.color[0], self.color[1], self.color[2]))
         if isFilled:    
-            sdl2.sdlgfx.boxColor(window.renderer.renderer, self.x1, self.y1, self.x2, self.y2, sdl2.ext.Color(self.color[0], self.color[1], self.color[2]))
+            sdl2.sdlgfx.boxColor(*params)
         else:
-            sdl2.sdlgfx.rectangleColor(window.renderer.renderer, self.x1, self.y1, self.x2, self.y2, sdl2.ext.Color(self.color[0], self.color[1], self.color[2]))
+            sdl2.sdlgfx.rectangleColor(*params)


### PR DESCRIPTION
Examples now can run from inside the examples dir.

*"Simply"* add this to the top of the file before `import jelly`:
```python
import os
import sys
current_dir = os.path.dirname(os.path.abspath(__file__))
parent_dir = os.path.dirname(current_dir)
sys.path.append(parent_dir)
```

For some reason, `sys.path.append("..")` was not working for me, but this did.