### PR TITLE
Remove complexity in `circle.py` and `rect.py`

### DIFF
--- a/jelly/circle.py
+++ b/jelly/circle.py
@@ -9,7 +9,5 @@ class Circle:
         self.isFilled = isFilled
         self.color = color
 
-        
-        #  isFilled:
         params = (window.renderer.renderer, x, y, radius, self.color[0], self.color[1], self.color[2], 255)
         sdl2.sdlgfx.filledCircleRGBA(*params) if isFilled else sdl2.sdlgfx.circleRGBA(*params)

--- a/jelly/circle.py
+++ b/jelly/circle.py
@@ -9,7 +9,7 @@ class Circle:
         self.isFilled = isFilled
         self.color = color
 
-        if isFilled:
-            sdl2.sdlgfx.filledCircleRGBA(window.renderer.renderer, x, y, radius, self.color[0], self.color[1], self.color[2], 255)
-        else:
-            sdl2.sdlgfx.circleRGBA(window.renderer.renderer, x, y, radius, self.color[0], self.color[1], self.color[2], 255)
+        
+        #  isFilled:
+        params = (window.renderer.renderer, x, y, radius, self.color[0], self.color[1], self.color[2], 255)
+        sdl2.sdlgfx.filledCircleRGBA(*params) if isFilled else sdl2.sdlgfx.circleRGBA(*params)

--- a/jelly/rect.py
+++ b/jelly/rect.py
@@ -35,8 +35,5 @@ class Rect:
         self.window = window
         self.isFilled = isFilled
 
-        # *params destructures the tuple.
         params = (window.renderer.renderer, self.x1, self.y1, self.x2, self.y2, sdl2.ext.Color(self.color[0], self.color[1], self.color[2]))
-
-        # Shorthand if
         sdl2.sdlgfx.boxColor(*params) if isFilled else sdl2.sdlgfx.rectangleColor(*params)

--- a/jelly/rect.py
+++ b/jelly/rect.py
@@ -35,7 +35,8 @@ class Rect:
         self.window = window
         self.isFilled = isFilled
 
-        if isFilled:    
-            sdl2.sdlgfx.boxColor(window.renderer.renderer, self.x1, self.y1, self.x2, self.y2, sdl2.ext.Color(self.color[0], self.color[1], self.color[2]))
-        else:
-            sdl2.sdlgfx.rectangleColor(window.renderer.renderer, self.x1, self.y1, self.x2, self.y2, sdl2.ext.Color(self.color[0], self.color[1], self.color[2]))
+        # *params destructures the tuple.
+        params = (window.renderer.renderer, self.x1, self.y1, self.x2, self.y2, sdl2.ext.Color(self.color[0], self.color[1], self.color[2]))
+
+        # Shorthand if
+        sdl2.sdlgfx.boxColor(*params) if isFilled else sdl2.sdlgfx.rectangleColor(*params)


### PR DESCRIPTION
1. Put similar params in var params, and de-structured tuple using * operator
 - In order to add additional params, if needed, simply do the following:
```python
params = (...)

# Just add the params normally
func(*params, 255)
```
2. Simplified if expression to 1 line via inline if statement